### PR TITLE
Include keepalive_expiry when creating a new connection

### DIFF
--- a/httpx_socks/_async_transport.py
+++ b/httpx_socks/_async_transport.py
@@ -51,6 +51,7 @@ class AsyncProxyTransport(AsyncConnectionPool):
             connection = AsyncHTTPConnection(
                 origin=origin,
                 http2=self._http2,
+                keepalive_expiry=self._keepalive_expiry,
                 ssl_context=self._ssl_context,
                 socket=socket
             )

--- a/httpx_socks/_sync_transport.py
+++ b/httpx_socks/_sync_transport.py
@@ -47,6 +47,7 @@ class SyncProxyTransport(SyncConnectionPool):
             connection = SyncHTTPConnection(
                 origin=origin,
                 http2=self._http2,
+                keepalive_expiry=self._keepalive_expiry,
                 ssl_context=self._ssl_context,
                 socket=socket,
             )


### PR DESCRIPTION
Allow setting a keepalive_expiry for connections when creating a new transport.