### PR TITLE
Upgrade httpx dependency to support v0.27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httpx>=0.21.0,<0.27.0
+httpx>=0.21.0,<0.28.0
 httpcore>=0.17.3,<2.0
 anyio==3.*
 python-socks>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=['httpx_socks'],
     keywords='httpx asyncio socks socks5 socks4 http proxy',
     install_requires=[
-        'httpx>=0.21.0,<0.27.0',
+        'httpx>=0.21.0,<0.28.0',
         'httpcore>=0.17.3,<2.0',
         'python-socks>=2.0.0',
     ],


### PR DESCRIPTION
All tests were passing with Python 3.11 (and also 3.12).

This patch does not add Python 3.12 in tests as this would require upgrading some test dependencies (such as flake8).